### PR TITLE
Add Flask ASCII art app and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # pyats-test1
+
+This repository contains sample tests and a small Flask application which returns
+ASCII art.
+
+The application requires `flask` and `pytest` which should be installed with
+`pip`:
+
+```bash
+pip install flask pyfiglet pytest
+```
+
+Due to network restrictions in the execution environment these packages may fail
+to install. If installation succeeds, run the application with:
+
+```bash
+python ascii_app.py
+```
+
+Run tests with:
+
+```bash
+pytest
+```

--- a/ascii_app.py
+++ b/ascii_app.py
@@ -1,0 +1,24 @@
+try:
+    from flask import Flask
+except ImportError as e:
+    raise ImportError(
+        "Flask is required to run this application. Install it with 'pip install flask'."
+    ) from e
+
+ASCII_ART = (
+    "  _____ _           _\n"
+    " |  ___(_)_ __   __| | ___\n"
+    " | |_  | | '_ \\ / _` |/ _ \\\n"
+    " |  _| | | | | | (_| |  __/\n"
+    " |_|   |_|_| |_|\__,_|\___|\n"
+)
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    # Return ASCII art wrapped in preformatted text for browser display
+    return f"<pre>{ASCII_ART}</pre>"
+
+if __name__ == '__main__':
+    app.run()

--- a/tests/test_ascii_app.py
+++ b/tests/test_ascii_app.py
@@ -1,0 +1,12 @@
+import pytest
+
+import ascii_app
+
+
+def test_index_route():
+    app = ascii_app.app
+    app.testing = True
+    client = app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert ascii_app.ASCII_ART in resp.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- add small Flask app that returns ASCII art
- add pytest for the Flask endpoint
- update README with setup and usage information

## Testing
- `pip install flask pyfiglet pytest` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: command not found)